### PR TITLE
Polepszenie wyglądu i funkcjonalności widgetu Beszel

### DIFF
--- a/docs/BESZEL_WIDGET_PL.md
+++ b/docs/BESZEL_WIDGET_PL.md
@@ -10,7 +10,8 @@ Aby skonfigurować widget Beszel, dodaj następującą konfigurację do swojego 
 - type: beszel
   url: https://twoja-instancja-beszel.pl    # URL do Twojej instancji Beszel (API)
   redirect-url: https://twoja-instancja-beszel.pl # URL do interfejsu webowego Beszel 
-  token: twoj-token-jwt                     # Token JWT (
+  token: twoj-token-jwt                     # Token JWT
+  show-charts: true                         # Włączenie wykresów (domyślnie true)
   cache: 10s                                # Częstotliwość odświeżania (domyślnie 10s)
 ```
 
@@ -47,6 +48,35 @@ Po najechaniu kursorem na ikonę serwera lub paski postępu, wyświetlane są do
 
 Jeśli skonfigurowano parametr `redirect-url`, kliknięcie w nazwę serwera otworzy nową kartę z szczegółowymi statystykami tego konkretnego systemu w panelu Beszel.
 
+### 5. Wykresy historyczne (NOWOŚĆ)
+
+Dla każdego serwera dostępny jest interaktywny wykres pokazujący dane historyczne. Wykresy można dostosować poprzez:
+
+#### Typy metryk:
+- **CPU** - użycie procesora w procentach
+- **RAM** - użycie pamięci w procentach
+- **Dysk** - zajętość dysku w procentach
+- **Sieć** - przesłane + odebrane dane w MB
+
+#### Zakresy czasowe:
+- **1h** - ostatnia godzina (dane co 1 minutę)
+- **12h** - ostatnie 12 godzin (dane co 10 minut)
+- **24h** - ostatnie 24 godziny (dane co 20 minut)
+- **7d** - ostatnie 7 dni (dane co 2 godziny)
+- **30d** - ostatnie 30 dni (dane co 8 godzin)
+
+#### Interakcja z wykresem:
+- Najedź kursorem na wykres, aby zobaczyć dokładne wartości w tooltipie
+- Wartości są wyświetlane z etykietą czasową
+
+#### Wyłączanie wykresów:
+Jeśli nie chcesz wyświetlać wykresów, możesz je wyłączyć:
+```yaml
+- type: beszel
+  url: https://beszel.example.com
+  show-charts: false
+```
+
 ## Przykładowa konfiguracja
 
 ```yaml
@@ -59,7 +89,8 @@ pages:
             title: Serwery
             url: https://beszel.example.com
             redirect-url: https://beszel.example.com
-            token: TWóJ_TOKEN
+            token: TWÓJ_TOKEN
+            show-charts: true
             cache: 5s
 ```
 
@@ -74,3 +105,14 @@ pages:
 ### Brakujące metryki
 
 Niektóre metryki (np. Load Average) mogą nie być dostępne w zależności od wersji agenta Beszel zainstalowanego na monitorowanym serwerze.
+
+### Wykresy nie ładują się
+
+1. Sprawdź czy endpoint `/api/collections/system_stats/records` jest dostępny.
+2. Upewnij się, że Beszel zbiera dane statystyczne - wykresy wymagają danych historycznych.
+3. Sprawdź konsolę przeglądarki pod kątem błędów JavaScript.
+
+### Brak danych na wykresie
+
+1. Beszel może nie mieć wystarczającej ilości danych historycznych dla wybranego zakresu czasowego.
+2. Spróbuj wybrać krótszy zakres czasowy (np. 1h zamiast 30d).

--- a/internal/glance/static/css/widget-beszel.css
+++ b/internal/glance/static/css/widget-beszel.css
@@ -1,0 +1,462 @@
+/* Beszel Widget CSS */
+
+/* System container */
+.beszel-system {
+    padding: 1rem;
+    margin-bottom: 1rem;
+    background: hsla(var(--bghs), calc(var(--bgl) + 2%), 0.5);
+    border-radius: var(--border-radius);
+    border: 1px solid var(--color-widget-content-border);
+}
+
+.beszel-system:last-child {
+    margin-bottom: 0;
+}
+
+/* Header */
+.beszel-header {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 0.75rem;
+    margin-bottom: 0.75rem;
+}
+
+.beszel-header-left {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    min-width: 0;
+    flex: 1;
+}
+
+.beszel-header-right {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+    align-items: center;
+    flex-shrink: 0;
+}
+
+.beszel-title {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+}
+
+.beszel-title a,
+.beszel-title span {
+    text-decoration: none;
+}
+
+.beszel-title a:hover {
+    text-decoration: underline;
+}
+
+/* Uptime / Host info */
+.beszel-uptime {
+    display: flex;
+    align-items: center;
+    gap: 0.3rem;
+    font-size: var(--font-size-h6);
+    color: var(--color-text-subdue);
+}
+
+.beszel-icon-small {
+    width: 12px;
+    height: 12px;
+    flex-shrink: 0;
+    opacity: 0.7;
+}
+
+/* Status badge */
+.beszel-status {
+    font-size: var(--font-size-h6);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    padding: 0.15rem 0.5rem;
+    border-radius: 0.25rem;
+    font-weight: 500;
+}
+
+.beszel-status-up {
+    background: hsla(var(--color-positive-hsl), 0.15);
+    color: var(--color-positive);
+}
+
+.beszel-status-down {
+    background: hsla(var(--color-negative-hsl), 0.15);
+    color: var(--color-negative);
+}
+
+/* Badges - statystyki po prawej */
+.beszel-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    padding: 0.2rem 0.5rem;
+    font-size: var(--font-size-h6);
+    font-weight: 500;
+    background: hsla(var(--bghs), calc(var(--bgl) + 10%), 0.8);
+    border: 1px solid hsla(var(--bghs), calc(var(--bgl) + 20%), 0.5);
+    border-radius: 0.3rem;
+    color: var(--color-text-highlight);
+    white-space: nowrap;
+}
+
+.beszel-badge-icon {
+    width: 12px;
+    height: 12px;
+    flex-shrink: 0;
+    opacity: 0.8;
+}
+
+.beszel-badge-version {
+    background: hsla(var(--color-primary-hsl), 0.15);
+    border-color: hsla(var(--color-primary-hsl), 0.3);
+    color: var(--color-primary);
+}
+
+.beszel-badge-uptime {
+    background: hsla(var(--color-positive-hsl), 0.1);
+    border-color: hsla(var(--color-positive-hsl), 0.25);
+    color: var(--color-positive);
+}
+
+.beszel-badge-warning {
+    background: hsla(var(--color-negative-hsl), 0.15);
+    border-color: hsla(var(--color-negative-hsl), 0.3);
+    color: var(--color-negative);
+}
+
+/* Meta info */
+.beszel-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem 1rem;
+    font-size: var(--font-size-h6);
+    color: var(--color-text-subdue);
+}
+
+.beszel-meta-item {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3rem;
+}
+
+.beszel-icon {
+    width: 14px;
+    height: 14px;
+    flex-shrink: 0;
+    opacity: 0.7;
+}
+
+.beszel-version {
+    background: hsla(var(--bghs), calc(var(--bgl) + 8%), 0.5);
+    padding: 0.1rem 0.4rem;
+    border-radius: 0.2rem;
+    font-size: 0.7rem;
+}
+
+/* Stats */
+.beszel-stats {
+    display: flex;
+    gap: 1rem;
+}
+
+.beszel-stat {
+    flex: 1;
+    min-width: 0;
+}
+
+.beszel-stat-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    margin-bottom: 0.3rem;
+}
+
+.beszel-stat-label {
+    font-size: var(--font-size-h6);
+    color: var(--color-text-subdue);
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+}
+
+.beszel-stat-value {
+    font-size: var(--font-size-h5);
+    color: var(--color-text-highlight);
+    font-weight: 500;
+}
+
+/* Separator dla systemów offline */
+.beszel-offline-separator {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    margin: 1.5rem 0 1rem 0;
+    padding-top: 1rem;
+}
+
+.beszel-offline-separator::before,
+.beszel-offline-separator::after {
+    content: '';
+    flex: 1;
+    height: 1px;
+    background: linear-gradient(to right, transparent, var(--color-negative), transparent);
+    opacity: 0.3;
+}
+
+.beszel-offline-label {
+    font-size: var(--font-size-h5);
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: var(--color-negative);
+    font-weight: 500;
+}
+
+/* Style dla systemów offline */
+.beszel-system-offline {
+    opacity: 0.6;
+    border-color: hsla(var(--color-negative-hsl), 0.3);
+}
+
+.beszel-system-offline .beszel-header {
+    margin-bottom: 0;
+}
+
+/* Kontener wykresu */
+.beszel-chart-container {
+    margin-top: 0.75rem;
+    padding-top: 0.75rem;
+    border-top: 1px solid var(--color-widget-content-border);
+}
+
+/* Kontrolki - lepszy layout */
+.beszel-chart-controls {
+    display: flex;
+    gap: 0.75rem;
+    margin-bottom: 0.6rem;
+    align-items: center;
+}
+
+.beszel-control-group {
+    display: flex;
+    align-items: center;
+    gap: 0.35rem;
+}
+
+.beszel-control-label {
+    font-size: var(--font-size-h6);
+    color: var(--color-text-subdue);
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+}
+
+/* Select - nowoczesny wygląd */
+.beszel-select {
+    appearance: none;
+    -webkit-appearance: none;
+    background-color: hsla(var(--bghs), calc(var(--bgl) + 8%), 0.6);
+    border: 1px solid hsla(var(--bghs), calc(var(--bgl) + 15%), 0.5);
+    border-radius: 0.35rem;
+    color: var(--color-text-highlight);
+    padding: 0.3rem 1.5rem 0.3rem 0.5rem;
+    font-size: var(--font-size-h6);
+    font-family: inherit;
+    font-weight: 500;
+    cursor: pointer;
+    outline: none;
+    transition: all 0.15s ease;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='10' viewBox='0 0 24 24' fill='none' stroke='%23888' stroke-width='2.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M6 9l6 6 6-6'/%3E%3C/svg%3E");
+    background-repeat: no-repeat;
+    background-position: right 0.4rem center;
+    background-size: 10px;
+    min-width: 70px;
+}
+
+.beszel-select:hover {
+    background-color: hsla(var(--bghs), calc(var(--bgl) + 12%), 0.8);
+    border-color: hsla(var(--bghs), calc(var(--bgl) + 20%), 0.7);
+}
+
+.beszel-select:focus {
+    border-color: var(--color-primary);
+    box-shadow: 0 0 0 2px hsla(var(--color-primary-hsl), 0.2);
+}
+
+.beszel-select option {
+    background-color: var(--color-widget-background);
+    color: var(--color-text-base);
+    padding: 0.5rem;
+}
+
+/* Wrapper wykresu z osią Y */
+.beszel-chart-wrapper {
+    display: flex;
+    gap: 0.4rem;
+}
+
+/* Oś Y */
+.beszel-chart-y-axis {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    align-items: flex-end;
+    padding: 0.2rem 0;
+    min-width: 38px;
+}
+
+.beszel-y-label {
+    font-size: var(--font-size-h6);
+    color: var(--color-text-base);
+    line-height: 1;
+    font-weight: 500;
+}
+
+/* Wykres */
+.beszel-chart {
+    position: relative;
+    flex: 1;
+    background: linear-gradient(
+        to bottom,
+        transparent 0%,
+        hsla(var(--bghs), calc(var(--bgl) + 3%), 0.3) 100%
+    );
+    border-radius: var(--border-radius);
+    padding: 0.2rem 0;
+    height: 90px;
+}
+
+.beszel-chart-svg {
+    display: block;
+    width: 100%;
+    height: 100%;
+    position: relative;
+    z-index: 1;
+}
+
+.beszel-chart-svg polyline {
+    filter: drop-shadow(0 1px 2px hsla(var(--bghs), var(--bgl), 0.3));
+}
+
+/* Cursor */
+.beszel-chart-cursor {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    width: 1px;
+    background-color: var(--color-primary);
+    pointer-events: none;
+    opacity: 0;
+    transition: opacity 0.15s;
+    z-index: 2;
+}
+
+/* Tooltip */
+.beszel-chart-tooltip {
+    position: absolute;
+    background: var(--color-popover-background);
+    border: 1px solid var(--color-popover-border);
+    border-radius: var(--border-radius);
+    padding: 0.3rem 0.5rem;
+    pointer-events: none;
+    opacity: 0;
+    transition: opacity 0.15s;
+    z-index: 10;
+    font-size: var(--font-size-h6);
+    box-shadow: 0 4px 12px -2px hsla(var(--bghs), var(--bgl), 0.4);
+    white-space: nowrap;
+}
+
+.beszel-chart-tooltip .tooltip-time {
+    color: var(--color-text-subdue);
+    font-size: var(--font-size-h6);
+}
+
+.beszel-chart-tooltip .tooltip-value {
+    color: var(--color-text-highlight);
+    font-weight: 500;
+}
+
+/* Loading */
+.beszel-chart-loading {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: hsla(var(--bghs), var(--bgl), 0.8);
+    border-radius: var(--border-radius);
+    z-index: 5;
+}
+
+.beszel-spinner {
+    width: 16px;
+    height: 16px;
+    border: 2px solid var(--color-widget-content-border);
+    border-top-color: var(--color-primary);
+    border-radius: 50%;
+    animation: beszel-spin 0.6s linear infinite;
+}
+
+@keyframes beszel-spin {
+    to {
+        transform: rotate(360deg);
+    }
+}
+
+/* Oś czasu */
+.beszel-chart-axis {
+    position: relative;
+    height: 1rem;
+    margin-top: 0.15rem;
+    margin-left: 42px; /* Wyrównanie z wykresem (min-width osi Y + gap) */
+}
+
+.beszel-axis-label {
+    position: absolute;
+    font-size: var(--font-size-h6);
+    color: var(--color-text-subdue);
+    white-space: nowrap;
+    line-height: 1;
+}
+
+/* Responsywność */
+@container widget (max-width: 450px) {
+    .beszel-header {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+    
+    .beszel-header-right {
+        width: 100%;
+        justify-content: flex-start;
+        margin-top: 0.25rem;
+    }
+}
+
+@container widget (max-width: 350px) {
+    .beszel-chart-controls {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 0.5rem;
+    }
+    
+    .beszel-control-group {
+        width: 100%;
+        justify-content: space-between;
+    }
+    
+    .beszel-stats {
+        flex-direction: column;
+        gap: 0.5rem;
+    }
+    
+    .beszel-meta {
+        flex-direction: column;
+        gap: 0.3rem;
+    }
+}

--- a/internal/glance/static/css/widgets.css
+++ b/internal/glance/static/css/widgets.css
@@ -1,4 +1,5 @@
 @import "widget-bookmarks.css";
+@import "widget-beszel.css";
 @import "widget-calendar.css";
 @import "widget-clock.css";
 @import "widget-dns-stats.css";

--- a/internal/glance/static/js/beszel.js
+++ b/internal/glance/static/js/beszel.js
@@ -1,0 +1,198 @@
+export default function setupBeszel(widgetElement) {
+    console.log('setupBeszel called', widgetElement);
+    const chartContainers = widgetElement.querySelectorAll('.beszel-chart-container');
+    
+    console.log('Found chart containers:', chartContainers.length);
+    
+    if (chartContainers.length === 0) {
+        return;
+    }
+
+    chartContainers.forEach(container => {
+        initializeChart(container);
+    });
+}
+
+function initializeChart(container) {
+    console.log('initializeChart called', container);
+    const widgetId = container.dataset.widgetId;
+    const systemId = container.dataset.systemId;
+    console.log('widgetId:', widgetId, 'systemId:', systemId);
+    
+    const metricSelect = container.querySelector('.beszel-metric-select');
+    const timeSelect = container.querySelector('.beszel-time-select');
+    const chartElement = container.querySelector('.beszel-chart');
+    const chartSvg = container.querySelector('.beszel-chart-svg polyline');
+    const tooltip = container.querySelector('.beszel-chart-tooltip');
+    const cursor = container.querySelector('.beszel-chart-cursor');
+    const axisContainer = container.querySelector('.beszel-chart-axis');
+    const loadingElement = container.querySelector('.beszel-chart-loading');
+    const dataScript = container.querySelector('.beszel-chart-data');
+    const yAxisMax = container.querySelector('.beszel-y-max');
+    const yAxisMid = container.querySelector('.beszel-y-mid');
+    const yAxisMin = container.querySelector('.beszel-y-min');
+
+    if (!widgetId || !systemId) {
+        console.error('Beszel chart: brak widgetId lub systemId');
+        if (loadingElement) loadingElement.style.display = 'none';
+        return;
+    }
+
+    let seriesData = [];
+
+    // Funkcja do pobierania danych wykresu
+    async function fetchChartData() {
+        const metric = metricSelect.value;
+        const timeRange = timeSelect.value;
+        
+        console.log('fetchChartData called', { metric, timeRange, widgetId, systemId });
+
+        loadingElement.style.display = 'flex';
+        chartSvg.setAttribute('points', '');
+
+        try {
+            const url = `${pageData.baseURL}/api/beszel/${widgetId}/chart`;
+            console.log('Fetching from:', url);
+            
+            const response = await fetch(url, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify({
+                    system_id: systemId,
+                    metric: metric,
+                    time_range: timeRange
+                }),
+            });
+
+            console.log('Response status:', response.status);
+            
+            if (!response.ok) {
+                const errorText = await response.text();
+                console.error('Nie udało się pobrać danych wykresu:', errorText);
+                loadingElement.style.display = 'none';
+                return;
+            }
+
+            const data = await response.json();
+            console.log('Received data:', data);
+            seriesData = data.series || [];
+            
+            // Aktualizacja wykresu
+            if (data.points) {
+                console.log('Setting points:', data.points.substring(0, 100) + '...');
+                chartSvg.setAttribute('points', data.points);
+            }
+
+            // Aktualizacja etykiet osi Y z min/max z backendu
+            const minValue = data.minValue !== undefined ? data.minValue : 0;
+            const maxValue = data.maxValue !== undefined ? data.maxValue : 100;
+            updateYAxisLabels(metric, minValue, maxValue);
+
+            // Aktualizacja etykiet osi X
+            updateAxisLabels(axisContainer, data.axisLabels || []);
+
+            // Zapisz dane do scriptu dla tooltip
+            dataScript.textContent = JSON.stringify(seriesData);
+
+        } catch (error) {
+            console.error('Błąd podczas pobierania danych wykresu:', error);
+        } finally {
+            loadingElement.style.display = 'none';
+        }
+    }
+
+    // Funkcja do aktualizacji etykiet osi Y
+    function updateYAxisLabels(metric, minValue, maxValue) {
+        if (!yAxisMax || !yAxisMid || !yAxisMin) return;
+        
+        const midValue = (minValue + maxValue) / 2;
+        
+        if (metric === 'network') {
+            // Dla sieci - wartości w MB
+            yAxisMax.textContent = maxValue.toFixed(1) + ' MB';
+            yAxisMid.textContent = midValue.toFixed(1) + ' MB';
+            yAxisMin.textContent = minValue.toFixed(1) + ' MB';
+        } else {
+            // Dla CPU, RAM, Disk - procentowe wartości
+            yAxisMax.textContent = maxValue.toFixed(0) + '%';
+            yAxisMid.textContent = midValue.toFixed(0) + '%';
+            yAxisMin.textContent = minValue.toFixed(0) + '%';
+        }
+    }
+
+    // Funkcja do aktualizacji etykiet osi X
+    function updateAxisLabels(axisContainer, labels) {
+        axisContainer.innerHTML = '';
+        labels.forEach(label => {
+            const labelEl = document.createElement('div');
+            labelEl.className = 'text-compact color-subdue beszel-axis-label';
+            labelEl.style.position = 'absolute';
+            labelEl.style.left = `${label.left}%`;
+            labelEl.style.transform = label.transform;
+            labelEl.style.whiteSpace = 'nowrap';
+            labelEl.style.fontSize = 'var(--font-size-h6)';
+            labelEl.textContent = label.label;
+            axisContainer.appendChild(labelEl);
+        });
+    }
+
+    // Event listenery dla selectów
+    metricSelect.addEventListener('change', fetchChartData);
+    timeSelect.addEventListener('change', fetchChartData);
+
+    // Interakcja z wykresem (tooltip i cursor)
+    chartElement.addEventListener('mousemove', (e) => {
+        if (seriesData.length === 0) return;
+
+        const rect = chartElement.getBoundingClientRect();
+        const x = e.clientX - rect.left;
+        const width = rect.width;
+
+        let index = Math.round((x / width) * (seriesData.length - 1));
+        index = Math.max(0, Math.min(index, seriesData.length - 1));
+
+        const point = seriesData[index];
+        if (!point) return;
+
+        const metric = metricSelect.value;
+        let unit = '%';
+        let valueDisplay = point.value.toFixed(1);
+
+        if (metric === 'network') {
+            unit = ' MB';
+            valueDisplay = point.value.toFixed(2);
+        }
+
+        // Aktualizacja tooltip
+        tooltip.innerHTML = `
+            <div class="text-label" style="margin-bottom: 0.2rem;">${point.label}</div>
+            <div class="color-highlight">${valueDisplay}${unit}</div>
+        `;
+
+        // Pozycjonowanie tooltip
+        const tooltipRect = tooltip.getBoundingClientRect();
+        let tooltipLeft = x - (tooltipRect.width / 2);
+
+        if (tooltipLeft < 0) tooltipLeft = 0;
+        if (tooltipLeft + tooltipRect.width > width) tooltipLeft = width - tooltipRect.width;
+
+        tooltip.style.left = `${tooltipLeft}px`;
+        tooltip.style.top = `-${tooltipRect.height + 5}px`;
+        tooltip.style.opacity = '1';
+
+        // Pozycjonowanie cursor
+        const pointX = (index / (seriesData.length - 1)) * width;
+        cursor.style.left = `${pointX}px`;
+        cursor.style.opacity = '1';
+    });
+
+    chartElement.addEventListener('mouseleave', () => {
+        tooltip.style.opacity = '0';
+        cursor.style.opacity = '0';
+    });
+
+    // Ładowanie początkowych danych
+    fetchChartData();
+}

--- a/internal/glance/static/js/page.js
+++ b/internal/glance/static/js/page.js
@@ -686,6 +686,17 @@ async function setupCloudflare() {
     }
 }
 
+async function setupBeszel() {
+    const elems = Array.from(document.getElementsByClassName("widget-type-beszel"));
+    if (elems.length == 0) return;
+
+    const beszel = await import ('./beszel.js');
+
+    for (let i = 0; i < elems.length; i++){
+        beszel.default(elems[i]);
+    }
+}
+
 function setupTruncatedElementTitles() {
     const elements = document.querySelectorAll(".text-truncate, .single-line-titles .title, .text-truncate-2-lines, .text-truncate-3-lines");
 
@@ -871,6 +882,7 @@ async function setupPage() {
         await setupRadyjko();
         await setupVikunja();
         await setupCloudflare();
+        await setupBeszel();
         setupCarousels();
         setupSearchBoxes();
         setupCollapsibleLists();

--- a/internal/glance/templates.go
+++ b/internal/glance/templates.go
@@ -41,6 +41,12 @@ var globalTemplateFunctions = template.FuncMap{
 	"formatPriceWithPrecision": func(precision int, price float64) string {
 		return intl.Sprintf("%."+strconv.Itoa(precision)+"f", price)
 	},
+	"divideFloat": func(a, b float64) float64 {
+		if b == 0 {
+			return 0
+		}
+		return a / b
+	},
 	"dynamicRelativeTimeAttrs": dynamicRelativeTimeAttrs,
 	"formatServerMegabytes": func(mb uint64) template.HTML {
 		var value string

--- a/internal/glance/templates/beszel.html
+++ b/internal/glance/templates/beszel.html
@@ -2,87 +2,146 @@
 
 {{- define "widget-content" }}
 {{- $redirect := .RedirectURL }}
-{{- range .Systems }}
-<div class="server">
-    <div class="server-info">
-        <div class="server-details">
-            <div class="server-name size-h3">
+{{- $showCharts := .ShowCharts }}
+{{- $widgetID := .GetID }}
+{{- $beszelURL := .URL }}
+
+{{/* Systemy Online */}}
+{{- range .OnlineSystems }}
+<div class="beszel-system" data-system-id="{{ .ID }}" data-system-name="{{ .Name }}">
+    <div class="beszel-header">
+        <div class="beszel-header-left">
+            <div class="beszel-title">
                 {{ if ne $redirect "" }}
-                <a class="color-highlight" href="{{ $redirect }}/system/{{ .Name }}" target="_blank" rel="noopener">{{ .Name }}</a>
+                <a class="color-highlight size-h3" href="{{ $redirect }}/system/{{ .Name }}" target="_blank" rel="noopener">{{ .Name }}</a>
                 {{ else }}
-                <span class="color-highlight">{{ .Name }}</span>
+                <span class="color-highlight size-h3">{{ .Name }}</span>
                 {{ end }}
-            </div>
-            <div>
-                {{ if eq .Status "up" }}
-                    <span {{ dynamicRelativeTimeAttrs .BootTime }}></span> uptime
-                {{ else }}
-                    <span class="color-negative">down</span>
-                {{ end }}
+                <span class="beszel-status beszel-status-up">online</span>
             </div>
         </div>
-        <div class="shrink-0" data-popover-type="html" data-popover-margin="0.2rem" data-popover-max-width="400px">
-            <div data-popover-html>
-                <div class="size-h5 text-compact">HOST</div>
-                <div class="color-highlight">{{ .Host }}</div>
-                
-                <div class="size-h5 text-compact margin-top-3">KERNEL</div>
-                <div class="color-highlight">{{ .Info.Kernel }}</div>
-
-                <div class="size-h5 text-compact margin-top-3">CPU MODEL</div>
-                <div class="color-highlight">{{ .Info.CPUModel }}</div>
-            </div>
-            <svg class="server-icon" stroke="var(--color-{{ if eq .Status "up" }}positive{{ else }}negative{{ end }})" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5">
-                <path stroke-linecap="round" stroke-linejoin="round" d="M21.75 17.25v-.228a4.5 4.5 0 0 0-.12-1.03l-2.268-9.64a3.375 3.375 0 0 0-3.285-2.602H7.923a3.375 3.375 0 0 0-3.285 2.602l-2.268 9.64a4.5 4.5 0 0 0-.12 1.03v.228m19.5 0a3 3 0 0 1-3 3H5.25a3 3 0 0 1-3-3m19.5 0a3 3 0 0 0-3-3H5.25a3 3 0 0 0-3 3m16.5 0h.008v.008h-.008v-.008Zm-3 0h.008v.008h-.008v-.008Z" />
-            </svg>
+        <div class="beszel-header-right">
+            <span class="beszel-badge beszel-badge-uptime" title="Uptime">
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="beszel-badge-icon">
+                    <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm.75-13a.75.75 0 00-1.5 0v5c0 .414.336.75.75.75h4a.75.75 0 000-1.5h-3.25V5z" clip-rule="evenodd" />
+                </svg>
+                <span {{ dynamicRelativeTimeAttrs .BootTime }}></span>
+            </span>
+            <span class="beszel-badge" title="CPU: {{ .Info.Cores }} rdzeni / {{ .Info.Threads }} wątków">
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="beszel-badge-icon">
+                    <path d="M14 6H6v8h8V6z" />
+                    <path fill-rule="evenodd" d="M9.25 3V1.75a.75.75 0 011.5 0V3h1.5V1.75a.75.75 0 011.5 0V3h.5A2.75 2.75 0 0117 5.75v.5h1.25a.75.75 0 010 1.5H17v1.5h1.25a.75.75 0 010 1.5H17v1.5h1.25a.75.75 0 010 1.5H17v.5A2.75 2.75 0 0114.25 17h-.5v1.25a.75.75 0 01-1.5 0V17h-1.5v1.25a.75.75 0 01-1.5 0V17h-1.5v1.25a.75.75 0 01-1.5 0V17h-.5A2.75 2.75 0 013 14.25v-.5H1.75a.75.75 0 010-1.5H3v-1.5H1.75a.75.75 0 010-1.5H3v-1.5H1.75a.75.75 0 010-1.5H3v-.5A2.75 2.75 0 015.75 3h.5V1.75a.75.75 0 011.5 0V3h1.5zM4.5 5.75c0-.69.56-1.25 1.25-1.25h8.5c.69 0 1.25.56 1.25 1.25v8.5c0 .69-.56 1.25-1.25 1.25h-8.5c-.69 0-1.25-.56-1.25-1.25v-8.5z" clip-rule="evenodd" />
+                </svg>
+                {{ .Info.Cores }}C/{{ .Info.Threads }}T
+            </span>
+            <span class="beszel-badge{{ if ge .Info.CPU 85.0 }} beszel-badge-warning{{ end }}" title="Użycie CPU: {{ printf "%.1f" .Info.CPU }}%&#10;Model: {{ .Info.CPUModel }}&#10;Load: {{ .Info.Load1 }} / {{ .Info.Load5 }} / {{ .Info.Load15 }}">
+                CPU {{ printf "%.0f" .Info.CPU }}%
+            </span>
+            <span class="beszel-badge{{ if ge .Info.Memory 85.0 }} beszel-badge-warning{{ end }}" title="Użycie RAM: {{ printf "%.1f" .Info.Memory }}%">
+                RAM {{ printf "%.0f" .Info.Memory }}%
+            </span>
+            <span class="beszel-badge{{ if ge .Info.Disk 85.0 }} beszel-badge-warning{{ end }}" title="Użycie dysku: {{ printf "%.1f" .Info.Disk }}%">
+                DISK {{ printf "%.0f" .Info.Disk }}%
+            </span>
+            {{ if .Info.AgentVersion }}
+            <span class="beszel-badge beszel-badge-version" title="Agent Beszel v{{ .Info.AgentVersion }}">
+                v{{ .Info.AgentVersion }}
+            </span>
+            {{ end }}
         </div>
     </div>
-    <div class="server-stats">
-        <div class="flex-1">
-            <div class="flex items-end size-h5">
-                <div>CPU</div>
-                <div class="color-highlight margin-left-auto text-very-compact">{{ printf "%.1f" .Info.CPU }} <span class="color-base">%</span></div>
+    
+    {{- if $showCharts }}
+    <div class="beszel-chart-container" data-widget-id="{{ $widgetID }}" data-system-id="{{ .ID }}">
+        <div class="beszel-chart-controls">
+            <div class="beszel-control-group">
+                <span class="beszel-control-label">Metryka</span>
+                <select class="beszel-select beszel-metric-select">
+                    <option value="cpu" selected>CPU</option>
+                    <option value="ram">RAM</option>
+                    <option value="disk">Dysk</option>
+                    <option value="network">Sieć</option>
+                </select>
             </div>
-            <div class="progress-bar" data-popover-type="html">
-                <div data-popover-html>
-                    <div class="flex">
-                        <div class="size-h5">1M AVG</div>
-                        <div class="value-separator"></div>
-                        <div class="color-highlight text-very-compact">{{ .Info.Load1 }}</div>
-                    </div>
-                    <div class="flex margin-top-3">
-                        <div class="size-h5">5M AVG</div>
-                        <div class="value-separator"></div>
-                        <div class="color-highlight text-very-compact">{{ .Info.Load5 }}</div>
-                    </div>
-                    <div class="flex margin-top-3">
-                        <div class="size-h5">15M AVG</div>
-                        <div class="value-separator"></div>
-                        <div class="color-highlight text-very-compact">{{ .Info.Load15 }}</div>
-                    </div>
+            <div class="beszel-control-group">
+                <span class="beszel-control-label">Okres</span>
+                <select class="beszel-select beszel-time-select">
+                    <option value="1h" selected>1 godz</option>
+                    <option value="12h">12 godz</option>
+                    <option value="24h">24 godz</option>
+                    <option value="7d">7 dni</option>
+                    <option value="30d">30 dni</option>
+                </select>
+            </div>
+        </div>
+        <div class="beszel-chart-wrapper">
+            <div class="beszel-chart-y-axis">
+                <span class="beszel-y-label beszel-y-max">100%</span>
+                <span class="beszel-y-label beszel-y-mid">50%</span>
+                <span class="beszel-y-label beszel-y-min">0%</span>
+            </div>
+            <div class="beszel-chart">
+                <div class="beszel-chart-cursor"></div>
+                <div class="beszel-chart-tooltip"></div>
+                <svg class="beszel-chart-svg" viewBox="0 0 100 50" preserveAspectRatio="none">
+                    <polyline
+                        fill="none"
+                        stroke="var(--color-primary)"
+                        stroke-width="1.5"
+                        points=""
+                        vector-effect="non-scaling-stroke"
+                    />
+                </svg>
+                <div class="beszel-chart-loading">
+                    <span class="beszel-spinner"></span>
                 </div>
-                <div class="progress-value{{ if ge .Info.CPU 85.0 }} progress-value-notice{{ end }}" style="--percent: {{ .Info.CPU }}"></div>
             </div>
         </div>
-        <div class="flex-1">
-            <div class="flex items-end size-h5">
-                <div>RAM</div>
-                <div class="color-highlight margin-left-auto text-very-compact">{{ printf "%.1f" .Info.Memory }} <span class="color-base">%</span></div>
-            </div>
-            <div class="progress-bar">
-                <div class="progress-value{{ if ge .Info.Memory 85.0 }} progress-value-notice{{ end }}" style="--percent: {{ .Info.Memory }}"></div>
+        <div class="beszel-chart-axis"></div>
+        <script type="application/json" class="beszel-chart-data">[]</script>
+    </div>
+    {{- end }}
+</div>
+{{- end }}
+
+{{/* Systemy Offline - z separatorem */}}
+{{- if .OfflineSystems }}
+<div class="beszel-offline-separator">
+    <span class="beszel-offline-label">Offline</span>
+</div>
+{{- range .OfflineSystems }}
+<div class="beszel-system beszel-system-offline" data-system-id="{{ .ID }}" data-system-name="{{ .Name }}">
+    <div class="beszel-header">
+        <div class="beszel-header-left">
+            <div class="beszel-title">
+                {{ if ne $redirect "" }}
+                <a class="color-highlight size-h3" href="{{ $redirect }}/system/{{ .Name }}" target="_blank" rel="noopener">{{ .Name }}</a>
+                {{ else }}
+                <span class="color-highlight size-h3">{{ .Name }}</span>
+                {{ end }}
+                <span class="beszel-status beszel-status-down">offline</span>
             </div>
         </div>
-        <div class="flex-1">
-            <div class="flex items-end size-h5">
-                <div>DISK</div>
-                <div class="color-highlight margin-left-auto text-very-compact">{{ printf "%.1f" .Info.Disk }} <span class="color-base">%</span></div>
-            </div>
-            <div class="progress-bar">
-                <div class="progress-value{{ if ge .Info.Disk 85.0 }} progress-value-notice{{ end }}" style="--percent: {{ .Info.Disk }}"></div>
-            </div>
+        <div class="beszel-header-right">
+            <span class="beszel-badge" title="Host: {{ .Host }}">
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="beszel-badge-icon">
+                    <path d="M4.632 3.533A2 2 0 016.577 2h6.846a2 2 0 011.945 1.533l1.976 8.234A3.489 3.489 0 0016 11.5H4c-.476 0-.93.095-1.344.267l1.976-8.234z" />
+                    <path fill-rule="evenodd" d="M4 13a2 2 0 100 4h12a2 2 0 100-4H4zm11.24 2a.75.75 0 01.75-.75H16a.75.75 0 01.75.75v.01a.75.75 0 01-.75.75h-.01a.75.75 0 01-.75-.75V15zm-2.25-.75a.75.75 0 00-.75.75v.01c0 .414.336.75.75.75H13a.75.75 0 00.75-.75V15a.75.75 0 00-.75-.75h-.01z" clip-rule="evenodd" />
+                </svg>
+                {{ .Host }}
+            </span>
+            {{ if .Info.Cores }}
+            <span class="beszel-badge" title="CPU: {{ .Info.Cores }} rdzeni / {{ .Info.Threads }} wątków">
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="beszel-badge-icon">
+                    <path d="M14 6H6v8h8V6z" />
+                    <path fill-rule="evenodd" d="M9.25 3V1.75a.75.75 0 011.5 0V3h1.5V1.75a.75.75 0 011.5 0V3h.5A2.75 2.75 0 0117 5.75v.5h1.25a.75.75 0 010 1.5H17v1.5h1.25a.75.75 0 010 1.5H17v1.5h1.25a.75.75 0 010 1.5H17v.5A2.75 2.75 0 0114.25 17h-.5v1.25a.75.75 0 01-1.5 0V17h-1.5v1.25a.75.75 0 01-1.5 0V17h-1.5v1.25a.75.75 0 01-1.5 0V17h-.5A2.75 2.75 0 013 14.25v-.5H1.75a.75.75 0 010-1.5H3v-1.5H1.75a.75.75 0 010-1.5H3v-1.5H1.75a.75.75 0 010-1.5H3v-.5A2.75 2.75 0 015.75 3h.5V1.75a.75.75 0 011.5 0V3h1.5zM4.5 5.75c0-.69.56-1.25 1.25-1.25h8.5c.69 0 1.25.56 1.25 1.25v8.5c0 .69-.56 1.25-1.25 1.25h-8.5c-.69 0-1.25-.56-1.25-1.25v-8.5z" clip-rule="evenodd" />
+                </svg>
+                {{ .Info.Cores }}C/{{ .Info.Threads }}T
+            </span>
+            {{ end }}
         </div>
     </div>
 </div>
+{{- end }}
 {{- end }}
 {{- end }}

--- a/internal/glance/widget-beszel.go
+++ b/internal/glance/widget-beszel.go
@@ -3,19 +3,27 @@ package glance
 import (
 	"context"
 	"errors"
+	"fmt"
 	"html/template"
 	"net/http"
+	"net/url"
+	"slices"
+	"sort"
 	"time"
 )
 
 var beszelWidgetTemplate = mustParseTemplate("beszel.html", "widget-base.html")
 
 type beszelWidget struct {
-	widgetBase  `yaml:",inline"`
-	URL         string         `yaml:"url"`
-	Token       string         `yaml:"token"`
-	RedirectURL string         `yaml:"redirect-url"`
-	Systems     []beszelSystem `yaml:"-"`
+	widgetBase      `yaml:",inline"`
+	URL             string         `yaml:"url"`
+	Token           string         `yaml:"token"`
+	RedirectURL     string         `yaml:"redirect-url"`
+	ShowChartsRaw   *bool          `yaml:"show-charts"`
+	ShowCharts      bool           `yaml:"-"`
+	Systems         []beszelSystem `yaml:"-"`
+	OnlineSystems   []beszelSystem `yaml:"-"`
+	OfflineSystems  []beszelSystem `yaml:"-"`
 }
 
 type beszelResponse struct {
@@ -23,6 +31,7 @@ type beszelResponse struct {
 }
 
 type beszelSystem struct {
+	ID       string     `json:"id"`
 	Name     string     `json:"name"`
 	Host     string     `json:"host"`
 	Status   string     `json:"status"`
@@ -31,21 +40,73 @@ type beszelSystem struct {
 }
 
 type beszelInfo struct {
-	Kernel   string  `json:"k"`
-	Uptime   float64 `json:"u"`
-	CPUModel string  `json:"m"`
-	CPU      float64 `json:"cpu"`
-	Memory   float64 `json:"mp"`
-	Disk     float64 `json:"dp"`
-	Load1    float64 `json:"l1"`
-	Load5    float64 `json:"l5"`
-	Load15   float64 `json:"l15"`
+	Kernel       string  `json:"k"`
+	Uptime       float64 `json:"u"`
+	CPUModel     string  `json:"m"`
+	CPU          float64 `json:"cpu"`
+	Memory       float64 `json:"mp"`
+	Disk         float64 `json:"dp"`
+	Load1        float64 `json:"l1"`
+	Load5        float64 `json:"l5"`
+	Load15       float64 `json:"l15"`
+	Cores        int     `json:"c"`
+	Threads      int     `json:"t"`
+	AgentVersion string  `json:"v"`
+	Hostname     string  `json:"h"`
+}
+
+// Struktury dla danych wykresów
+type beszelChartResponse struct {
+	Items []beszelStatsRecord `json:"items"`
+}
+
+type beszelStatsRecord struct {
+	Created string      `json:"created"`
+	Stats   beszelStats `json:"stats"`
+}
+
+type beszelStats struct {
+	CPU         float64   `json:"cpu"`
+	Mem         float64   `json:"m"`
+	MemUsed     float64   `json:"mu"`
+	MemPct      float64   `json:"mp"`
+	DiskTotal   float64   `json:"d"`
+	DiskUsed    float64   `json:"du"`
+	DiskPct     float64   `json:"dp"`
+	NetworkSent float64   `json:"ns"`
+	NetworkRecv float64   `json:"nr"`
+	LoadAvg     []float64 `json:"la"`
+}
+
+type beszelChartData struct {
+	Points     string                   `json:"points"`
+	Series     []beszelChartSeriesPoint `json:"series"`
+	AxisLabels []beszelAxisLabel        `json:"axisLabels"`
+	MinValue   float64                  `json:"minValue"`
+	MaxValue   float64                  `json:"maxValue"`
+}
+
+type beszelChartSeriesPoint struct {
+	Label string  `json:"label"`
+	Value float64 `json:"value"`
+}
+
+type beszelAxisLabel struct {
+	Label     string  `json:"label"`
+	Left      float64 `json:"left"`
+	Transform string  `json:"transform"`
 }
 
 func (w *beszelWidget) initialize() error {
 	w.withTitle("Beszel").withCacheDuration(10 * time.Second)
 	if w.URL == "" {
 		return errors.New("beszel widget: url is required")
+	}
+	// Domyślnie wykresy są włączone, chyba że użytkownik ustawił show-charts: false
+	if w.ShowChartsRaw == nil {
+		w.ShowCharts = true
+	} else {
+		w.ShowCharts = *w.ShowChartsRaw
 	}
 	return nil
 }
@@ -73,9 +134,196 @@ func (w *beszelWidget) update(ctx context.Context) {
 		w.Systems[i].BootTime = now.Add(-time.Duration(w.Systems[i].Info.Uptime) * time.Second)
 	}
 
+	// Sortuj systemy - online najpierw, offline na końcu
+	sort.Slice(w.Systems, func(i, j int) bool {
+		if w.Systems[i].Status == "up" && w.Systems[j].Status != "up" {
+			return true
+		}
+		if w.Systems[i].Status != "up" && w.Systems[j].Status == "up" {
+			return false
+		}
+		return w.Systems[i].Name < w.Systems[j].Name
+	})
+
+	// Rozdziel systemy na online i offline
+	w.OnlineSystems = nil
+	w.OfflineSystems = nil
+	for _, sys := range w.Systems {
+		if sys.Status == "up" {
+			w.OnlineSystems = append(w.OnlineSystems, sys)
+		} else {
+			w.OfflineSystems = append(w.OfflineSystems, sys)
+		}
+	}
+
 	w.withError(nil).scheduleNextUpdate()
 }
 
 func (w *beszelWidget) Render() template.HTML {
 	return w.renderTemplate(w, beszelWidgetTemplate)
+}
+
+// FetchChartData pobiera dane wykresu dla konkretnego systemu
+func (w *beszelWidget) FetchChartData(systemID string, metricType string, timeRange string) (*beszelChartData, error) {
+	// Mapowanie timeRange na typ rekordu w Beszel
+	// Beszel przechowuje dane w typach: 1m, 10m, 20m, 120m, 480m
+	recordType := "1m"
+	var timeFilter string
+	now := time.Now().UTC()
+
+	// Format daty zgodny z Beszel API (bez milisekund, bez Z)
+	const beszelTimeFormat = "2006-01-02 15:04:05"
+
+	switch timeRange {
+	case "1h":
+		// Ostatnia godzina - dane co 1m, ~60 punktów
+		recordType = "1m"
+		timeFilter = now.Add(-1 * time.Hour).Format(beszelTimeFormat)
+	case "12h":
+		// Ostatnie 12h - dane co 10m, ~72 punkty
+		recordType = "10m"
+		timeFilter = now.Add(-12 * time.Hour).Format(beszelTimeFormat)
+	case "24h":
+		// Ostatnie 24h - dane co 20m, ~72 punkty
+		recordType = "20m"
+		timeFilter = now.Add(-24 * time.Hour).Format(beszelTimeFormat)
+	case "7d":
+		// Ostatnie 7 dni - dane co 2h (120m), ~84 punkty
+		recordType = "120m"
+		timeFilter = now.AddDate(0, 0, -7).Format(beszelTimeFormat)
+	case "30d":
+		// Ostatnie 30 dni - dane co 8h (480m), ~90 punktów
+		recordType = "480m"
+		timeFilter = now.AddDate(0, 0, -30).Format(beszelTimeFormat)
+	default:
+		recordType = "1m"
+		timeFilter = now.Add(-1 * time.Hour).Format(beszelTimeFormat)
+	}
+
+	// Budowanie URL z filtrem - format zgodny z Beszel API
+	filter := fmt.Sprintf("system='%s' && created > '%s' && type='%s'", systemID, timeFilter, recordType)
+	apiURL := fmt.Sprintf("%s/api/collections/system_stats/records?page=1&perPage=500&skipTotal=1&filter=%s&fields=created,stats&sort=created",
+		w.URL, url.QueryEscape(filter))
+
+	req, err := http.NewRequest("GET", apiURL, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if w.Token != "" {
+		req.Header.Set("Authorization", "Bearer "+w.Token)
+	}
+
+	resp, err := decodeJsonFromRequest[*beszelChartResponse](defaultHTTPClient, req)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(resp.Items) == 0 {
+		return nil, errors.New("no data available")
+	}
+
+	// Ekstrakcja wartości na podstawie typu metryki
+	values := make([]float64, len(resp.Items))
+	series := make([]beszelChartSeriesPoint, len(resp.Items))
+
+	for i, item := range resp.Items {
+		var value float64
+		switch metricType {
+		case "cpu":
+			value = item.Stats.CPU
+		case "ram":
+			value = item.Stats.MemPct
+		case "disk":
+			value = item.Stats.DiskPct
+		case "network":
+			value = item.Stats.NetworkSent + item.Stats.NetworkRecv
+		default:
+			value = item.Stats.CPU
+		}
+		values[i] = value
+
+		// Parsowanie czasu dla etykiety
+		t, _ := time.Parse("2006-01-02 15:04:05.000Z", item.Created)
+		if t.IsZero() {
+			t, _ = time.Parse(time.RFC3339, item.Created)
+		}
+
+		var label string
+		switch timeRange {
+		case "1h", "12h":
+			label = t.Format("15:04")
+		case "24h":
+			label = t.Format("15:04")
+		case "7d", "30d":
+			label = t.Format("02.01")
+		default:
+			label = t.Format("15:04")
+		}
+
+		series[i] = beszelChartSeriesPoint{
+			Label: label,
+			Value: value,
+		}
+	}
+
+	// Generowanie punktów SVG
+	chartPoints := svgPolylineCoordsFromYValues(100, 50, values)
+
+	// Obliczanie min/max dla osi Y
+	minValue := slices.Min(values)
+	maxValue := slices.Max(values)
+
+	// Generowanie etykiet osi
+	axisLabels := generateBeszelAxisLabels(series, timeRange)
+
+	return &beszelChartData{
+		Points:     chartPoints,
+		Series:     series,
+		AxisLabels: axisLabels,
+		MinValue:   minValue,
+		MaxValue:   maxValue,
+	}, nil
+}
+
+func generateBeszelAxisLabels(series []beszelChartSeriesPoint, timeRange string) []beszelAxisLabel {
+	numPoints := len(series)
+	if numPoints < 2 {
+		return nil
+	}
+
+	var indices []int
+	switch timeRange {
+	case "1h":
+		indices = []int{0, numPoints / 4, numPoints / 2, 3 * numPoints / 4, numPoints - 1}
+	case "12h", "24h":
+		indices = []int{0, numPoints / 3, 2 * numPoints / 3, numPoints - 1}
+	case "7d":
+		indices = []int{0, numPoints / 3, 2 * numPoints / 3, numPoints - 1}
+	case "30d":
+		indices = []int{0, numPoints / 4, numPoints / 2, 3 * numPoints / 4, numPoints - 1}
+	default:
+		indices = []int{0, numPoints / 2, numPoints - 1}
+	}
+
+	labels := make([]beszelAxisLabel, 0, len(indices))
+	for _, idx := range indices {
+		if idx >= 0 && idx < numPoints {
+			left := (float64(idx) / float64(numPoints-1)) * 100
+			transform := "translateX(-50%)"
+			if idx == 0 {
+				transform = "translateX(0)"
+			} else if idx == numPoints-1 {
+				transform = "translateX(-100%)"
+			}
+
+			labels = append(labels, beszelAxisLabel{
+				Label:     series[idx].Label,
+				Left:      left,
+				Transform: transform,
+			})
+		}
+	}
+
+	return labels
 }


### PR DESCRIPTION
## Nowy wygląd i układ widgetu

- Nagłówek systemu zawiera wszystkie informacje w jednej linii: uptime, CPU (rdzenie/wątki), użycie CPU%, RAM%, DISK%, wersja agenta
- Badge'e automatycznie zmieniają kolor na czerwony gdy użycie przekracza 85%
- Dodano wyraźny wizualny separator między systemami Online i Offline


## Interaktywne wykresy historyczne

- Dodano opcję konfiguracyjną `show-charts: true/false`
- Wykresy przedstawiają dane dla: CPU, RAM, Dysk, Sieć
- Dostępne zakresy czasowe: 1h, 12h, 24h, 7 dni, 30 dni
- Interaktywny tooltip pokazuje dokładne wartości po najechaniu kursorem


## Backend - nowe API

- Nowy endpoint `/api/beszel/{widgetID}/chart` do pobierania danych wykresów
- Zwracanie min/max wartości dla dynamicznej osi Y


## Responsywność

- Widget dostosowuje się do mniejszych ekranów
- Badge'e zawijają się do nowej linii na wąskich ekranach
- Kontrolki wykresów układają się pionowo na małych urządzeniach

